### PR TITLE
Implementation of ACORN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+datasets
+
 ### Linux ###
 *~
 

--- a/scripts/acorn_benchmark.py
+++ b/scripts/acorn_benchmark.py
@@ -244,6 +244,18 @@ def search_acorn1(
     return [int(i) for i in ids]
 
 
+def search_acorn_gamma(
+    index,
+    query: np.ndarray,
+    k: int,
+    ef_search: int,
+    predicate,
+) -> list[int]:
+    """ACORN-γ filtered search (pre-expanded neighbor lists, no two-hop at query time)."""
+    _distances, ids = index.search_filtered_gamma(query, k, ef_search, predicate)
+    return [int(i) for i in ids]
+
+
 def run_all_benchmarks(
     index,
     payloads: list[dict],
@@ -254,11 +266,12 @@ def run_all_benchmarks(
     selectivities: list[float],
 ) -> list[dict]:
     """
-    Run post-filter and ACORN-1 on the same queries and return per-method stats.
+    Run post-filter, ACORN-1, and ACORN-γ on the same queries and return per-method stats.
 
     Methods:
       - Post-filter  : HNSW search then discard non-matching results
       - ACORN-1      : two-hop predicate-aware graph traversal
+      - ACORN-γ      : pre-expanded neighbor lists, no two-hop at query time
 
     `selectivities` is pre-computed once by the caller so it is shared across
     multiple ef_search sweeps.
@@ -273,6 +286,10 @@ def run_all_benchmarks(
         (
             f"ACORN-1      (ef={ef_search})",
             lambda q, pred: search_acorn1(index, q, k, ef_search, pred),
+        ),
+        (
+            f"ACORN-gamma  (ef={ef_search})",
+            lambda q, pred: search_acorn_gamma(index, q, k, ef_search, pred),
         ),
     ]
 
@@ -342,6 +359,11 @@ def main() -> None:
     )
     parser.add_argument("--m", type=int, default=16, help="HNSW M parameter.")
     parser.add_argument("--ef-construction", type=int, default=200, help="ef_construction parameter.")
+    parser.add_argument(
+        "--gamma", type=int, nargs="+", default=[2],
+        metavar="G",
+        help="One or more ACORN-γ expansion factors to sweep (e.g. --gamma 2 4 8).",
+    )
     parser.add_argument("--n-queries", type=int, default=50, help="Number of test queries to run.")
     args = parser.parse_args()
 
@@ -398,7 +420,7 @@ def main() -> None:
     print(f"Index built in {build_time:.1f}s\n")
 
     # ------------------------------------------------------------------
-    # Pre-compute selectivities once (shared across all ef sweeps)
+    # Pre-compute selectivities once (shared across all sweeps)
     # ------------------------------------------------------------------
     n_queries = min(args.n_queries, len(tests))
     print(f"Pre-computing selectivities for {n_queries} queries ...")
@@ -409,46 +431,63 @@ def main() -> None:
     print(f"  Mean selectivity: {np.mean(selectivities):.2%}\n")
 
     # ------------------------------------------------------------------
-    # Sweep over ef_search values, reusing the same index each time
+    # Sweep over gamma × ef_search combinations
+    # Each gamma requires rebuilding the expanded neighbor lists once;
+    # all ef_search values for that gamma reuse the same expansion.
     # ------------------------------------------------------------------
+    gamma_values = sorted(set(args.gamma))
     ef_values = sorted(set(args.ef_search))
 
-    all_tables = {}
-    for ef in ef_values:
-        print(f"\n{'─'*60}")
-        print(f"  ef_search = {ef}")
-        print(f"{'─'*60}")
-        all_tables[ef] = run_all_benchmarks(
-            index, payloads, tests,
-            k=args.k,
-            ef_search=ef,
-            n_queries=n_queries,
-            selectivities=selectivities,
-        )
+    # all_tables[(gamma, ef)] = list of per-method stats dicts
+    all_tables: dict[tuple[int, int], list[dict]] = {}
+
+    for gamma in gamma_values:
+        print(f"\n{'═'*60}")
+        print(f"  Building ACORN-γ expanded neighbors (gamma={gamma}) ...")
+        t0 = time.perf_counter()
+        index.build_acorn_gamma(gamma)
+        print(f"  Done in {time.perf_counter() - t0:.1f}s")
+        print(f"{'═'*60}")
+
+        for ef in ef_values:
+            print(f"\n{'─'*60}")
+            print(f"  gamma={gamma}  ef_search={ef}")
+            print(f"{'─'*60}")
+            all_tables[(gamma, ef)] = run_all_benchmarks(
+                index, payloads, tests,
+                k=args.k,
+                ef_search=ef,
+                n_queries=n_queries,
+                selectivities=selectivities,
+            )
 
     # ------------------------------------------------------------------
     # Print consolidated summary table
     # ------------------------------------------------------------------
-    print(f"\n{'='*80}")
+    print(f"\n{'='*88}")
     print(f"Summary  —  k={args.k}  selectivity≈{np.mean(selectivities):.1%}  "
           f"({n_queries} queries)")
-    print(f"{'='*80}")
-    header = f"{'ef':>6}  {'Method':<26}  {'Recall@k':>9}  {'Mean lat':>9}  {'p95 lat':>8}"
+    print(f"{'='*88}")
+    header = f"{'γ':>4}  {'ef':>6}  {'Method':<26}  {'Recall@k':>9}  {'Mean lat':>9}  {'p95 lat':>8}"
     print(header)
-    print("-" * 80)
-    for ef in ef_values:
-        for i, s in enumerate(all_tables[ef]):
-            ef_label = str(ef) if i == 0 else ""
-            row = (
-                f"{ef_label:>6}  "
-                f"{s['label']:<26}  "
-                f"{s['mean_recall']:>9.4f}  "
-                f"{s['mean_latency_ms']:>8.1f}ms  "
-                f"{s['p95_latency_ms']:>7.1f}ms"
-            )
-            print(row)
-        print()
-    print(f"{'='*80}\n")
+    print("-" * 88)
+    for gamma in gamma_values:
+        for ef in ef_values:
+            stats = all_tables[(gamma, ef)]
+            for i, s in enumerate(stats):
+                gamma_label = str(gamma) if i == 0 and ef == ef_values[0] else ""
+                ef_label = str(ef) if i == 0 else ""
+                row = (
+                    f"{gamma_label:>4}  "
+                    f"{ef_label:>6}  "
+                    f"{s['label']:<26}  "
+                    f"{s['mean_recall']:>9.4f}  "
+                    f"{s['mean_latency_ms']:>8.1f}ms  "
+                    f"{s['p95_latency_ms']:>7.1f}ms"
+                )
+                print(row)
+            print()
+    print(f"{'='*88}\n")
 
 
 if __name__ == "__main__":

--- a/scripts/acorn_benchmark.py
+++ b/scripts/acorn_benchmark.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""
+ACORN-1 filtered ANN search benchmark using the Qdrant filtered ANN benchmark datasets.
+
+Downloads a small dataset (100K vectors with metadata predicates), builds a standard
+DensePlainHNSW index, runs filtered search via ACORN-1, and reports recall and latency.
+
+Usage:
+    python acorn_benchmark.py                          # laion-small-clip (default)
+    python acorn_benchmark.py --dataset random_ints    # random integer predicates
+    python acorn_benchmark.py --k 10 --ef 200          # tune search params
+    python acorn_benchmark.py --n-queries 100          # limit number of test queries
+    python acorn_benchmark.py --data-dir /tmp/acorn    # custom download directory
+"""
+
+import argparse
+import json
+import os
+import sys
+import tarfile
+import time
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Dataset registry
+# ---------------------------------------------------------------------------
+
+DATASETS = {
+    "laion-small-clip": {
+        "url": "https://storage.googleapis.com/ann-filtered-benchmark/datasets/laion-small-clip.tgz",
+        "description": "100K LAION CLIP embeddings (512D), range predicates on a float attribute",
+        "metric": "dotproduct",   # cosine on normalised vectors = dot product
+    },
+    "random_ints": {
+        "url": "https://storage.googleapis.com/ann-filtered-benchmark/datasets/random_ints_100k.tgz",
+        "description": "100K random vectors (2048D), integer range predicates",
+        "metric": "dotproduct",
+    },
+    "random_keywords": {
+        "url": "https://storage.googleapis.com/ann-filtered-benchmark/datasets/random_keywords_100k.tgz",
+        "description": "100K random vectors (2048D), keyword / exact-match predicates",
+        "metric": "dotproduct",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Download helpers
+# ---------------------------------------------------------------------------
+
+def _progress_hook(block_num: int, block_size: int, total_size: int) -> None:
+    downloaded = block_num * block_size
+    if total_size > 0:
+        pct = min(downloaded / total_size * 100, 100)
+        bar = "#" * int(pct / 2)
+        print(f"\r  [{bar:<50}] {pct:5.1f}%", end="", flush=True)
+
+
+def download_and_extract(url: str, dest_dir: Path) -> Path:
+    """Download a .tgz dataset and extract it under dest_dir. Returns the dataset dir."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = dest_dir / Path(url).name
+
+    if not archive_path.exists():
+        print(f"Downloading {url} ...")
+        urllib.request.urlretrieve(url, archive_path, reporthook=_progress_hook)
+        print()  # newline after progress bar
+    else:
+        print(f"Archive already exists: {archive_path}")
+
+    # Inspect the archive to find the top-level directory (if any).
+    with tarfile.open(archive_path) as tf:
+        members = tf.getmembers()
+        top_level = {m.name.split("/")[0] for m in members}
+
+    if len(top_level) == 1:
+        dataset_dir = dest_dir / top_level.pop()
+    else:
+        # Files are at the archive root — put them in a named subdirectory.
+        # Use the stem without the first suffix only (handles .tgz and .tar.gz).
+        stem = archive_path.name
+        for ext in (".tgz", ".tar.gz", ".tar"):
+            if stem.endswith(ext):
+                stem = stem[: -len(ext)]
+                break
+        dataset_dir = dest_dir / stem
+
+    # Only skip extraction if the key output file is already present.
+    vectors_npy = dataset_dir / "vectors.npy"
+    if vectors_npy.exists():
+        print(f"Already extracted: {dataset_dir}")
+    else:
+        dataset_dir.mkdir(parents=True, exist_ok=True)
+        print(f"Extracting to {dataset_dir} ...")
+        with tarfile.open(archive_path) as tf:
+            if len(top_level) == 1:
+                tf.extractall(dest_dir)
+            else:
+                # Extract flat archives into the named subdirectory.
+                tf.extractall(dataset_dir)
+
+    return dataset_dir
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def load_jsonl(path: Path) -> list[dict]:
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def load_dataset(dataset_dir: Path):
+    """
+    Load vectors, payloads, and test queries from a Qdrant benchmark directory.
+
+    Returns:
+        vectors   – np.ndarray shape (n, dim), float32
+        payloads  – list of dicts, one per vector
+        tests     – list of dicts with keys: query, conditions, closest_ids, closest_scores
+    """
+    vectors_path = dataset_dir / "vectors.npy"
+    payloads_path = dataset_dir / "payloads.jsonl"
+    tests_path = dataset_dir / "tests.jsonl"
+
+    for p in (vectors_path, payloads_path, tests_path):
+        if not p.exists():
+            # Some datasets put files in a subdirectory
+            candidates = list(dataset_dir.rglob(p.name))
+            if not candidates:
+                raise FileNotFoundError(f"Expected file not found: {p}")
+            p = candidates[0]
+
+    print(f"Loading vectors from {vectors_path} ...")
+    vectors = np.load(vectors_path).astype(np.float32)
+
+    print(f"Loading payloads from {payloads_path} ...")
+    payloads = load_jsonl(payloads_path)
+
+    print(f"Loading tests from {tests_path} ...")
+    tests = load_jsonl(tests_path)
+
+    assert len(vectors) == len(payloads), (
+        f"Vector count {len(vectors)} != payload count {len(payloads)}"
+    )
+
+    return vectors, payloads, tests
+
+
+# ---------------------------------------------------------------------------
+# Predicate builder
+# ---------------------------------------------------------------------------
+
+def _check_condition(payload: dict, condition: dict) -> bool:
+    """Evaluate a single Qdrant filter condition against a payload dict."""
+    for field_name, filter_spec in condition.items():
+        value = payload.get(field_name)
+        if value is None:
+            return False
+
+        if "range" in filter_spec:
+            rng = filter_spec["range"]
+            if "gt"  in rng and not (value >  rng["gt"]):  return False
+            if "gte" in rng and not (value >= rng["gte"]): return False
+            if "lt"  in rng and not (value <  rng["lt"]):  return False
+            if "lte" in rng and not (value <= rng["lte"]): return False
+
+        elif "match" in filter_spec:
+            if value != filter_spec["match"]["value"]:
+                return False
+
+        else:
+            raise ValueError(f"Unknown filter spec: {filter_spec}")
+
+    return True
+
+
+def build_predicate(conditions: dict, payloads: list[dict]):
+    """
+    Convert a Qdrant conditions dict into a Python callable ``(int) -> bool``.
+
+    Supports the ``{"and": [...]}`` top-level structure and per-field
+    ``range`` / ``match`` conditions.
+    """
+    if "and" in conditions:
+        sub_conditions = conditions["and"]
+    else:
+        # Treat the whole dict as a single implicit-AND condition list
+        sub_conditions = [{k: v} for k, v in conditions.items()]
+
+    def predicate(vector_id: int) -> bool:
+        payload = payloads[vector_id]
+        return all(_check_condition(payload, cond) for cond in sub_conditions)
+
+    return predicate
+
+
+# ---------------------------------------------------------------------------
+# Benchmark logic
+# ---------------------------------------------------------------------------
+
+def estimate_selectivity(conditions: dict, payloads: list[dict], sample: int = 1000) -> float:
+    """Estimate the fraction of vectors passing the predicate (Monte-Carlo sample)."""
+    n = len(payloads)
+    indices = np.random.choice(n, size=min(sample, n), replace=False)
+    pred = build_predicate(conditions, payloads)
+    hits = sum(1 for i in indices if pred(int(i)))
+    return hits / len(indices)
+
+
+# --- search strategies ---
+
+def search_post_filter(
+    index,
+    query: np.ndarray,
+    k: int,
+    ef_search: int,
+    predicate,
+) -> list[int]:
+    """
+    Standard HNSW search followed by predicate filtering.
+
+    Fetches `ef_search` candidates (the maximum the HNSW is willing to explore),
+    then keeps only those satisfying the predicate. This is the naive baseline:
+    cheap to implement, but recall collapses when the predicate is selective.
+    """
+    _distances, ids = index.search(query, ef_search, ef_search)
+    passing = [int(i) for i in ids if predicate(int(i))]
+    return passing[:k]
+
+
+def search_acorn1(
+    index,
+    query: np.ndarray,
+    k: int,
+    ef_search: int,
+    predicate,
+) -> list[int]:
+    """ACORN-1 filtered search (two-hop expansion during graph traversal)."""
+    _distances, ids = index.search_filtered(query, k, ef_search, predicate)
+    return [int(i) for i in ids]
+
+
+def run_all_benchmarks(
+    index,
+    payloads: list[dict],
+    tests: list[dict],
+    k: int,
+    ef_search: int,
+    n_queries: int,
+    selectivities: list[float],
+) -> list[dict]:
+    """
+    Run post-filter and ACORN-1 on the same queries and return per-method stats.
+
+    Methods:
+      - Post-filter  : HNSW search then discard non-matching results
+      - ACORN-1      : two-hop predicate-aware graph traversal
+
+    `selectivities` is pre-computed once by the caller so it is shared across
+    multiple ef_search sweeps.
+    """
+    n_queries = min(n_queries, len(tests))
+
+    methods = [
+        (
+            f"Post-filter  (ef={ef_search})",
+            lambda q, pred: search_post_filter(index, q, k, ef_search, pred),
+        ),
+        (
+            f"ACORN-1      (ef={ef_search})",
+            lambda q, pred: search_acorn1(index, q, k, ef_search, pred),
+        ),
+    ]
+
+    # Run queries method-by-method so progress is easy to follow.
+    results = []
+    for label, search_fn in methods:
+        print(f"\n── {label} ──")
+
+        recalls = []
+        latencies_ms = []
+
+        for i, test in enumerate(tests[:n_queries]):
+            query = np.array(test["query"], dtype=np.float32)
+            ground_truth = set(test["closest_ids"][:k])
+            predicate = build_predicate(test["conditions"], payloads)
+
+            t0 = time.perf_counter()
+            result_ids = search_fn(query, predicate)
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            latencies_ms.append(elapsed_ms)
+
+            result_set = set(result_ids)
+            recall = len(result_set & ground_truth) / len(ground_truth) if ground_truth else 1.0
+            recalls.append(recall)
+
+            if (i + 1) % 10 == 0 or (i + 1) == n_queries:
+                print(
+                    f"  [{i+1:3d}/{n_queries}]  recall={recall:.2f}  "
+                    f"sel={selectivities[i]:.2%}  lat={elapsed_ms:.1f}ms",
+                    flush=True,
+                )
+
+        results.append({
+            "label": label,
+            "mean_recall": float(np.mean(recalls)),
+            "median_recall": float(np.median(recalls)),
+            "mean_latency_ms": float(np.mean(latencies_ms)),
+            "p50_latency_ms": float(np.percentile(latencies_ms, 50)),
+            "p95_latency_ms": float(np.percentile(latencies_ms, 95)),
+            "mean_selectivity": float(np.mean(selectivities)),
+        })
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark ACORN-1 filtered ANN search with kannolo.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--dataset",
+        choices=list(DATASETS),
+        default="laion-small-clip",
+        help="Dataset to download and benchmark.",
+    )
+    parser.add_argument("--data-dir", default="./datasets", help="Directory to store downloaded data.")
+    parser.add_argument("--k", type=int, default=10, help="Number of nearest neighbours to retrieve.")
+    parser.add_argument(
+        "--ef-search", type=int, nargs="+", default=[200],
+        metavar="EF",
+        help="One or more ef_search values to sweep (e.g. --ef-search 20 50 100 200).",
+    )
+    parser.add_argument("--m", type=int, default=16, help="HNSW M parameter.")
+    parser.add_argument("--ef-construction", type=int, default=200, help="ef_construction parameter.")
+    parser.add_argument("--n-queries", type=int, default=50, help="Number of test queries to run.")
+    args = parser.parse_args()
+
+    # ------------------------------------------------------------------
+    # Import kannolo (give a clear error if not installed)
+    # ------------------------------------------------------------------
+    try:
+        import kannolo
+    except ImportError:
+        print(
+            "ERROR: kannolo is not installed.\n"
+            "Build and install it with:  maturin develop --release",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # ------------------------------------------------------------------
+    # Download / load dataset
+    # ------------------------------------------------------------------
+    ds_info = DATASETS[args.dataset]
+    print(f"\n{'='*60}")
+    print(f"Dataset : {args.dataset}")
+    print(f"          {ds_info['description']}")
+    print(f"{'='*60}\n")
+
+    dataset_dir = download_and_extract(ds_info["url"], Path(args.data_dir))
+    vectors, payloads, tests = load_dataset(dataset_dir)
+
+    n, dim = vectors.shape
+    print(f"\nVectors : {n:,} × {dim}D  |  Tests: {len(tests):,}\n")
+
+    # Show a sample payload and test so the user knows the data format
+    print("── Sample payload ──────────────────────────────")
+    print(json.dumps(payloads[0], indent=2))
+    print("\n── Sample test ─────────────────────────────────")
+    sample_test = {k: v for k, v in tests[0].items() if k != "query"}
+    sample_test["query"] = f"[{dim}D vector]"
+    print(json.dumps(sample_test, indent=2, default=str))
+    print()
+
+    # ------------------------------------------------------------------
+    # Build HNSW index
+    # ------------------------------------------------------------------
+    print(f"Building HNSW (M={args.m}, ef_construction={args.ef_construction}) ...")
+    t0 = time.perf_counter()
+    index = kannolo.DensePlainHNSW.build_from_array(
+        vectors.flatten(),
+        dim,
+        m=args.m,
+        ef_construction=args.ef_construction,
+        metric=ds_info["metric"],
+    )
+    build_time = time.perf_counter() - t0
+    print(f"Index built in {build_time:.1f}s\n")
+
+    # ------------------------------------------------------------------
+    # Pre-compute selectivities once (shared across all ef sweeps)
+    # ------------------------------------------------------------------
+    n_queries = min(args.n_queries, len(tests))
+    print(f"Pre-computing selectivities for {n_queries} queries ...")
+    selectivities = []
+    for test in tests[:n_queries]:
+        sel = estimate_selectivity(test["conditions"], payloads, sample=500)
+        selectivities.append(sel)
+    print(f"  Mean selectivity: {np.mean(selectivities):.2%}\n")
+
+    # ------------------------------------------------------------------
+    # Sweep over ef_search values, reusing the same index each time
+    # ------------------------------------------------------------------
+    ef_values = sorted(set(args.ef_search))
+
+    all_tables = {}
+    for ef in ef_values:
+        print(f"\n{'─'*60}")
+        print(f"  ef_search = {ef}")
+        print(f"{'─'*60}")
+        all_tables[ef] = run_all_benchmarks(
+            index, payloads, tests,
+            k=args.k,
+            ef_search=ef,
+            n_queries=n_queries,
+            selectivities=selectivities,
+        )
+
+    # ------------------------------------------------------------------
+    # Print consolidated summary table
+    # ------------------------------------------------------------------
+    print(f"\n{'='*80}")
+    print(f"Summary  —  k={args.k}  selectivity≈{np.mean(selectivities):.1%}  "
+          f"({n_queries} queries)")
+    print(f"{'='*80}")
+    header = f"{'ef':>6}  {'Method':<26}  {'Recall@k':>9}  {'Mean lat':>9}  {'p95 lat':>8}"
+    print(header)
+    print("-" * 80)
+    for ef in ef_values:
+        for i, s in enumerate(all_tables[ef]):
+            ef_label = str(ef) if i == 0 else ""
+            row = (
+                f"{ef_label:>6}  "
+                f"{s['label']:<26}  "
+                f"{s['mean_recall']:>9.4f}  "
+                f"{s['mean_latency_ms']:>8.1f}ms  "
+                f"{s['p95_latency_ms']:>7.1f}ms"
+            )
+            print(row)
+        print()
+    print(f"{'='*80}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -442,6 +442,98 @@ pub trait GraphTrait {
 
         top_candidates
     }
+
+    /// ACORN-γ filtered search on a pre-expanded neighbor graph.
+    ///
+    /// Unlike [`acorn_search_candidates_filtered`], this method performs **no two-hop
+    /// expansion** at query time. It is designed for use with [`AcornGammaNeighbors`]
+    /// whose `neighbors()` already returns γ·M pre-expanded candidates (two-hop union,
+    /// pruned by distance). Predicate-failing nodes are simply skipped without further
+    /// expansion — connectivity is guaranteed by the pre-built lists.
+    ///
+    /// # Arguments
+    /// Same as [`acorn_search_candidates_filtered`].
+    #[must_use]
+    fn acorn_gamma_search_filtered<'e, D, F>(
+        &self,
+        dataset: &'e D,
+        entry_node: ScoredItemGeneric<<D::Encoder as VectorEncoder>::Distance, usize>,
+        query_evaluator: &<D::Encoder as VectorEncoder>::Evaluator<'e>,
+        ef: usize,
+        k: usize,
+        lambda: f32,
+        predicate: &F,
+    ) -> BinaryHeap<ScoredItemGeneric<<D::Encoder as VectorEncoder>::Distance, usize>>
+    where
+        D: Dataset + Sync,
+        <D::Encoder as VectorEncoder>::Distance: Distance,
+        F: Fn(usize) -> bool,
+    {
+        let mut top_candidates: BinaryHeap<
+            ScoredItemGeneric<<D::Encoder as VectorEncoder>::Distance, usize>,
+        > = BinaryHeap::new();
+
+        let mut candidates: BinaryHeap<
+            Reverse<ScoredItemGeneric<<D::Encoder as VectorEncoder>::Distance, usize>>,
+        > = BinaryHeap::with_capacity(ef);
+
+        let mut visited = create_visited_set(dataset.len(), ef);
+
+        // Always add the entry to C (traversal); add to W (results) only if predicate passes.
+        visited.insert(entry_node.vector);
+        candidates.push(Reverse(entry_node));
+        if predicate(self.get_external_id(entry_node.vector)) {
+            top_candidates.push(entry_node);
+        }
+
+        while let Some(Reverse(node)) = candidates.pop() {
+            if top_candidates.len() >= ef.max(k) {
+                let worst_top = top_candidates.peek().unwrap().distance;
+                if !node.distance.is_within_relaxation(&worst_top, lambda) {
+                    break;
+                }
+            }
+
+            for neighbor_local in self.neighbors(node.vector) {
+                if visited.contains(neighbor_local) {
+                    continue;
+                }
+                visited.insert(neighbor_local);
+
+                let ext = self.get_external_id(neighbor_local);
+                let d = query_evaluator.compute_distance(dataset.get(ext as VectorId));
+                let cand = ScoredItemGeneric {
+                    distance: d,
+                    vector: neighbor_local,
+                };
+
+                // Gate on W's current frontier — same threshold as search_candidates_impl.
+                let should_add = if top_candidates.len() < ef {
+                    true
+                } else if let Some(top) = top_candidates.peek() {
+                    cand.distance.is_within_relaxation(&top.distance, lambda)
+                } else {
+                    false
+                };
+
+                if should_add {
+                    // Always add to C (traversal), even if the node fails the predicate —
+                    // non-predicate nodes act as stepping stones through the expanded graph.
+                    candidates.push(Reverse(cand));
+
+                    // Only add to W (results) if the predicate passes.
+                    if predicate(ext) {
+                        top_candidates.push(cand);
+                        if top_candidates.len() > ef {
+                            top_candidates.pop();
+                        }
+                    }
+                }
+            }
+        }
+
+        top_candidates
+    }
 }
 
 #[cfg(test)]
@@ -661,6 +753,111 @@ mod tests {
         results.truncate(k);
 
         // Node 7 is the exact nearest neighbor.
+        assert_eq!(results[0].vector, 7, "expected nearest node 7, got {}", results[0].vector);
+        assert_eq!(results[0].distance, SquaredEuclideanDistance::from(0.0));
+    }
+}
+
+#[cfg(test)]
+mod acorn_gamma_tests {
+    use super::*;
+    use vectorium::DenseDataset;
+    use vectorium::core::dataset::ScoredItemGeneric;
+    use vectorium::core::vector::DenseVectorView;
+    use vectorium::distances::SquaredEuclideanDistance;
+    use vectorium::encoders::dense_scalar::PlainDenseQuantizer;
+
+    fn build_line_graph(n: usize, max_degree: usize) -> GrowableGraph {
+        let mut g = GrowableGraph::with_max_degree(max_degree);
+        g.reserve(n);
+        g.advance_inserted_nodes(n);
+        for i in 0..n {
+            let mut nbrs: Vec<usize> = Vec::new();
+            if i > 0 {
+                nbrs.push(i - 1);
+            }
+            if i + 1 < n {
+                nbrs.push(i + 1);
+            }
+            g.push_with_precomputed_reverse_links(None, &nbrs, i, &[]);
+        }
+        g
+    }
+
+    /// All results from `acorn_gamma_search_filtered` must satisfy the predicate.
+    ///
+    /// On a standard (non-pre-expanded) graph, the method behaves like a predicate-aware
+    /// beam search that simply skips non-matching nodes — no two-hop expansion.
+    /// With a line graph and even-IDs predicate, nearest even node to 10.0 is node 10.
+    #[test]
+    fn acorn_gamma_filtered_results_all_pass_predicate() {
+        let n = 20usize;
+        let k = 5usize;
+        let ef = 10usize;
+
+        let encoder = PlainDenseQuantizer::<f32, SquaredEuclideanDistance>::new(1);
+        let flat: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        let dataset = DenseDataset::from_raw(flat.into_boxed_slice(), n, encoder);
+        let graph = build_line_graph(n, 4);
+
+        let query_val = [10.0f32];
+        let query = DenseVectorView::new(&query_val);
+        let evaluator = dataset.encoder().query_evaluator(query);
+        let entry_dist = evaluator.compute_distance(dataset.get(10));
+        let entry = ScoredItemGeneric {
+            distance: entry_dist,
+            vector: 10usize,
+        };
+
+        let predicate = |id: usize| id % 2 == 0;
+        let top_heap = graph.acorn_gamma_search_filtered(
+            &dataset,
+            entry,
+            &evaluator,
+            ef,
+            k,
+            0.0,
+            &predicate,
+        );
+
+        assert!(!top_heap.is_empty(), "expected at least one result");
+        for result in &top_heap {
+            assert_eq!(result.vector % 2, 0, "node {} fails even predicate", result.vector);
+        }
+        let best = top_heap.into_sorted_vec().into_iter().next().unwrap();
+        assert_eq!(best.vector, 10, "expected nearest even node 10, got {}", best.vector);
+        assert_eq!(best.distance, SquaredEuclideanDistance::from(0.0));
+    }
+
+    /// With an all-pass predicate, `acorn_gamma_search_filtered` must return the same
+    /// nearest neighbor as the standard unfiltered search.
+    #[test]
+    fn acorn_gamma_filtered_all_pass_matches_unfiltered_nearest() {
+        let n = 20usize;
+        let ef = 8usize;
+        let k = 3usize;
+
+        let encoder = PlainDenseQuantizer::<f32, SquaredEuclideanDistance>::new(1);
+        let flat: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        let dataset = DenseDataset::from_raw(flat.into_boxed_slice(), n, encoder);
+        let graph = build_line_graph(n, 4);
+
+        let query_val = [7.0f32];
+        let query = DenseVectorView::new(&query_val);
+        let evaluator = dataset.encoder().query_evaluator(query);
+        let entry_dist = evaluator.compute_distance(dataset.get(7));
+        let entry = ScoredItemGeneric {
+            distance: entry_dist,
+            vector: 7usize,
+        };
+
+        let all_pass = |_: usize| true;
+        let top_heap =
+            graph.acorn_gamma_search_filtered(&dataset, entry, &evaluator, ef, k, 0.0, &all_pass);
+
+        let mut results = top_heap.into_sorted_vec();
+        results.truncate(k);
+
         assert_eq!(results[0].vector, 7, "expected nearest node 7, got {}", results[0].vector);
         assert_eq!(results[0].distance, SquaredEuclideanDistance::from(0.0));
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -298,6 +298,150 @@ pub trait GraphTrait {
         }
         top_candidates
     }
+
+    /// Performs ACORN-1 filtered approximate nearest-neighbor search.
+    ///
+    /// Only vectors satisfying `predicate(external_id) == true` are returned.
+    /// To maintain connectivity in sparse predicate sub-graphs, the search performs a
+    /// two-hop neighbor expansion: when a direct neighbor does not satisfy the predicate,
+    /// its own neighbors are also inspected ("jumping over" non-matching nodes).
+    ///
+    /// # Arguments
+    /// * `dataset` – Dataset containing the raw vectors.
+    /// * `entry_node` – `(distance, local_id)` starting point for the search.
+    /// * `query_evaluator` – Computes distances from the query to any vector.
+    /// * `ef` – Dynamic candidate list size (controls recall vs. speed).
+    /// * `k` – Number of results requested (used for early-termination threshold).
+    /// * `lambda` – Relaxation parameter for adaptive early stopping (`0.0` = standard HNSW).
+    /// * `predicate` – Called with the **external** vector ID; returns `true` for eligible vectors.
+    #[must_use]
+    fn acorn_search_candidates_filtered<'e, D, F>(
+        &self,
+        dataset: &'e D,
+        entry_node: ScoredItemGeneric<<D::Encoder as VectorEncoder>::Distance, usize>,
+        query_evaluator: &<D::Encoder as VectorEncoder>::Evaluator<'e>,
+        ef: usize,
+        k: usize,
+        lambda: f32,
+        predicate: &F,
+    ) -> BinaryHeap<ScoredItemGeneric<<D::Encoder as VectorEncoder>::Distance, usize>>
+    where
+        D: Dataset + Sync,
+        <D::Encoder as VectorEncoder>::Distance: Distance,
+        F: Fn(usize) -> bool,
+    {
+        // max-heap: predicate-satisfying results (worst-first for eviction).
+        let mut top_candidates: BinaryHeap<
+            ScoredItemGeneric<<D::Encoder as VectorEncoder>::Distance, usize>,
+        > = BinaryHeap::new();
+
+        // min-heap: traversal candidates (best-first for greedy exploration).
+        let mut candidates: BinaryHeap<
+            Reverse<ScoredItemGeneric<<D::Encoder as VectorEncoder>::Distance, usize>>,
+        > = BinaryHeap::with_capacity(ef);
+
+        let mut visited = create_visited_set(dataset.len(), ef);
+
+        // Always add the entry to the traversal set so we can expand from it even
+        // when it does not satisfy the predicate.
+        visited.insert(entry_node.vector);
+        candidates.push(Reverse(entry_node));
+
+        // Only add the entry to the result set if it passes the predicate.
+        if predicate(self.get_external_id(entry_node.vector)) {
+            top_candidates.push(entry_node);
+        }
+
+        // Reusable buffer for non-predicate direct neighbors used in the two-hop phase;
+        // allocated once and cleared per iteration to avoid repeated heap allocations.
+        let mut non_pred_direct: Vec<usize> = Vec::new();
+
+        while let Some(Reverse(node)) = candidates.pop() {
+            // Standard HNSW termination: stop when the best remaining candidate
+            // cannot improve the worst result in the result set.
+            if top_candidates.len() >= ef.max(k) {
+                let worst_top = top_candidates.peek().unwrap().distance;
+                if !node.distance.is_within_relaxation(&worst_top, lambda) {
+                    break;
+                }
+            }
+
+            non_pred_direct.clear();
+
+            // --- Phase 1: direct neighbors ---
+            // Predicate-satisfying neighbors are admitted to the candidate/result heaps.
+            // Non-predicate neighbors are collected for the two-hop phase below.
+            for neighbor_local in self.neighbors(node.vector) {
+                if visited.contains(neighbor_local) {
+                    continue;
+                }
+                visited.insert(neighbor_local);
+
+                let ext = self.get_external_id(neighbor_local);
+                if predicate(ext) {
+                    let d = query_evaluator.compute_distance(dataset.get(ext as VectorId));
+                    let cand = ScoredItemGeneric {
+                        distance: d,
+                        vector: neighbor_local,
+                    };
+                    let should_add = if top_candidates.len() < ef {
+                        true
+                    } else if let Some(top) = top_candidates.peek() {
+                        cand.distance.is_within_relaxation(&top.distance, lambda)
+                    } else {
+                        false
+                    };
+                    if should_add {
+                        candidates.push(Reverse(cand));
+                        top_candidates.push(cand);
+                    }
+                    if top_candidates.len() > ef {
+                        top_candidates.pop();
+                    }
+                } else {
+                    non_pred_direct.push(neighbor_local);
+                }
+            }
+
+            // --- Phase 2: two-hop expansion (ACORN-1 core) ---
+            // For each non-predicate direct neighbor, inspect its neighbors.
+            // This compensates for sparse connectivity in the predicate sub-graph.
+            for &mid_local in &non_pred_direct {
+                for neighbor_local in self.neighbors(mid_local) {
+                    if visited.contains(neighbor_local) {
+                        continue;
+                    }
+                    visited.insert(neighbor_local);
+
+                    let ext = self.get_external_id(neighbor_local);
+                    if predicate(ext) {
+                        let d = query_evaluator.compute_distance(dataset.get(ext as VectorId));
+                        let cand = ScoredItemGeneric {
+                            distance: d,
+                            vector: neighbor_local,
+                        };
+                        let should_add = if top_candidates.len() < ef {
+                            true
+                        } else if let Some(top) = top_candidates.peek() {
+                            cand.distance.is_within_relaxation(&top.distance, lambda)
+                        } else {
+                            false
+                        };
+                        if should_add {
+                            candidates.push(Reverse(cand));
+                            top_candidates.push(cand);
+                        }
+                        if top_candidates.len() > ef {
+                            top_candidates.pop();
+                        }
+                    }
+                    // Non-predicate two-hop nodes are not expanded further (no three-hop).
+                }
+            }
+        }
+
+        top_candidates
+    }
 }
 
 #[cfg(test)]
@@ -403,6 +547,121 @@ mod tests {
             "expected nearest node 5, got {}",
             results[0].vector
         );
+        assert_eq!(results[0].distance, SquaredEuclideanDistance::from(0.0));
+    }
+
+    /// All results from `acorn_search_candidates_filtered` must satisfy the predicate.
+    ///
+    /// Dataset: 1-D vectors [0.0 … 19.0] on a line graph.
+    /// Query: 10.0.  Predicate: only even IDs.
+    /// The nearest even node is 10 (distance 0); the next nearest are 8 and 12.
+    #[test]
+    fn acorn_filtered_results_all_pass_predicate() {
+        let n = 20usize;
+        let k = 5usize;
+        let ef = 10usize;
+
+        let encoder = PlainDenseQuantizer::<f32, SquaredEuclideanDistance>::new(1);
+        let flat: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        let dataset = DenseDataset::from_raw(flat.into_boxed_slice(), n, encoder);
+        let graph = build_line_graph(n, 4);
+
+        let query_val = [10.0f32];
+        let query = DenseVectorView::new(&query_val);
+        let evaluator = dataset.encoder().query_evaluator(query);
+        let entry_dist = evaluator.compute_distance(dataset.get(0));
+        let entry = ScoredItemGeneric {
+            distance: entry_dist,
+            vector: 0usize,
+        };
+
+        let predicate = |id: usize| id % 2 == 0;
+        let top_heap =
+            graph.acorn_search_candidates_filtered(&dataset, entry, &evaluator, ef, k, 0.0, &predicate);
+
+        assert!(!top_heap.is_empty(), "expected at least one result");
+        for result in &top_heap {
+            assert_eq!(result.vector % 2, 0, "node {} fails even predicate", result.vector);
+        }
+
+        // The nearest even node to 10.0 is node 10 itself (distance 0).
+        let best = top_heap.into_sorted_vec().into_iter().next().unwrap();
+        assert_eq!(best.vector, 10, "expected nearest even node 10, got {}", best.vector);
+        assert_eq!(best.distance, SquaredEuclideanDistance::from(0.0));
+    }
+
+    /// When the entry point does not satisfy the predicate the search must still
+    /// find predicate-passing nodes via two-hop expansion.
+    ///
+    /// Line graph [0 … 19].  Entry = node 0 (fails `id >= 2`).
+    /// - Phase 1: neighbor 1 also fails → collected for two-hop.
+    /// - Phase 2: neighbors of 1 are {0, 2}; 0 is already visited; 2 passes → admitted.
+    /// So the two-hop expansion must discover node 2 even though neither entry
+    /// nor its direct neighbor satisfy the predicate.
+    #[test]
+    fn acorn_filtered_entry_not_in_predicate_still_finds_results() {
+        let n = 20usize;
+        let k = 3usize;
+        let ef = 10usize;
+
+        let encoder = PlainDenseQuantizer::<f32, SquaredEuclideanDistance>::new(1);
+        let flat: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        let dataset = DenseDataset::from_raw(flat.into_boxed_slice(), n, encoder);
+        let graph = build_line_graph(n, 4);
+
+        // Entry at node 0 — does NOT satisfy `id >= 2`.
+        // Node 1 (direct neighbor) also does not satisfy it.
+        // Node 2 (two hops away) does satisfy it and must be found.
+        let query_val = [3.0f32];
+        let query = DenseVectorView::new(&query_val);
+        let evaluator = dataset.encoder().query_evaluator(query);
+        let entry_dist = evaluator.compute_distance(dataset.get(0));
+        let entry = ScoredItemGeneric {
+            distance: entry_dist,
+            vector: 0usize,
+        };
+
+        let predicate = |id: usize| id >= 2;
+        let top_heap =
+            graph.acorn_search_candidates_filtered(&dataset, entry, &evaluator, ef, k, 0.0, &predicate);
+
+        assert!(!top_heap.is_empty(), "expected results even when entry and its direct neighbors fail predicate");
+        for result in &top_heap {
+            assert!(result.vector >= 2, "node {} fails id>=2 predicate", result.vector);
+        }
+    }
+
+    /// With a predicate that accepts every node, filtered search must return the same
+    /// nearest neighbor as the standard unfiltered search.
+    #[test]
+    fn acorn_filtered_all_pass_matches_unfiltered_nearest() {
+        let n = 20usize;
+        let ef = 8usize;
+        let k = 3usize;
+
+        let encoder = PlainDenseQuantizer::<f32, SquaredEuclideanDistance>::new(1);
+        let flat: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        let dataset = DenseDataset::from_raw(flat.into_boxed_slice(), n, encoder);
+        let graph = build_line_graph(n, 4);
+
+        let query_val = [7.0f32];
+        let query = DenseVectorView::new(&query_val);
+        let evaluator = dataset.encoder().query_evaluator(query);
+        let entry_dist = evaluator.compute_distance(dataset.get(0));
+        let entry = ScoredItemGeneric {
+            distance: entry_dist,
+            vector: 0usize,
+        };
+
+        let all_pass = |_: usize| true;
+        let top_heap =
+            graph.acorn_search_candidates_filtered(&dataset, entry, &evaluator, ef, k, 0.0, &all_pass);
+
+        let mut results = top_heap.into_sorted_vec();
+        results.truncate(k);
+
+        // Node 7 is the exact nearest neighbor.
+        assert_eq!(results[0].vector, 7, "expected nearest node 7, got {}", results[0].vector);
         assert_eq!(results[0].distance, SquaredEuclideanDistance::from(0.0));
     }
 }

--- a/src/indexes/hnsw.rs
+++ b/src/indexes/hnsw.rs
@@ -4,13 +4,72 @@ use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 use crate::graph::{GraphTrait, GrowableGraph};
 use crate::index::Index;
 use vectorium::IndexSerializer;
 use vectorium::core::dataset::{ConvertFrom, ConvertInto, ScoredItemGeneric};
+use vectorium::distances::Distance;
 use vectorium::vector_encoder::VectorEncoder;
 use vectorium::{Dataset, QueryEvaluator, SpaceUsage, VectorId};
+
+// ---------------------------------------------------------------------------
+// ACORN-γ pre-expanded neighbor structure
+// ---------------------------------------------------------------------------
+
+/// Pre-expanded ground-level neighbor lists for ACORN-γ filtered ANN search.
+///
+/// Built from a completed HNSW index by expanding each node's neighborhood to
+/// include two-hop candidates (neighbors of neighbors), scoring them by distance
+/// to that node, and retaining the top γ·M closest.
+///
+/// At search time, standard beam search is run over these larger lists; predicate-
+/// failing nodes are skipped without further expansion, because the two-hop
+/// connectivity is already embedded in the pre-built lists.
+///
+/// Use [`HNSW::build_acorn_gamma_neighbors`] to construct this.
+pub struct AcornGammaNeighbors {
+    /// `neighbors[v]` holds local node IDs of v's expanded neighborhood,
+    /// sorted by ascending distance to v.
+    neighbors: Box<[Box<[usize]>]>,
+    gamma_m: usize,
+}
+
+impl GraphTrait for AcornGammaNeighbors {
+    #[inline]
+    fn neighbors<'a>(&'a self, u: usize) -> impl Iterator<Item = usize> + 'a {
+        self.neighbors[u].iter().copied()
+    }
+
+    #[inline]
+    fn n_nodes(&self) -> usize {
+        self.neighbors.len()
+    }
+
+    #[inline]
+    fn n_edges(&self) -> usize {
+        self.neighbors.iter().map(|n| n.len()).sum()
+    }
+
+    #[inline]
+    fn max_degree(&self) -> usize {
+        self.gamma_m
+    }
+
+    /// Ground-level nodes use identity mapping (local ID == global ID).
+    #[inline]
+    fn get_external_id(&self, id: usize) -> usize {
+        id
+    }
+
+    fn get_space_usage_bytes(&self) -> usize {
+        self.neighbors
+            .iter()
+            .map(|n| n.len() * std::mem::size_of::<usize>())
+            .sum()
+    }
+}
 
 /// A `HNSW` struct represents a Hierarchical Navigable Small World (HNSW) graph structure that is used
 /// for approximate nearest neighbor (ANN) search.
@@ -338,6 +397,162 @@ where
         let ef = search_params.ef_search.max(k);
         let lambda = search_params.early_termination.lambda();
         let top_heap = ground_graph.acorn_search_candidates_filtered(
+            &self.dataset,
+            ground_entry_node,
+            &query_eval,
+            ef,
+            k,
+            lambda,
+            &predicate,
+        );
+
+        let mut topk = top_heap.into_sorted_vec();
+        topk.truncate(k);
+        topk.drain(..)
+            .map(|candidate| vectorium::dataset::ScoredVector {
+                distance: candidate.distance,
+                vector: candidate.vector as VectorId,
+            })
+            .collect()
+    }
+}
+
+impl<D, G> HNSW<D, G>
+where
+    D: Dataset + Sync,
+    <D::Encoder as VectorEncoder>::Distance: Distance,
+    G: GraphTrait + From<GrowableGraph>,
+{
+    /// Build pre-expanded neighbor lists for ACORN-γ filtered search.
+    ///
+    /// For each ground-level node `v`, the two-hop neighborhood (direct neighbors
+    /// and their neighbors) is scored by distance to `v` and pruned to `gamma * M`
+    /// entries, sorted closest-first.
+    ///
+    /// Call this **once** after the standard HNSW build, then pass the result to
+    /// [`search_filtered_gamma`] for fast predicate-aware search.
+    ///
+    /// # Arguments
+    /// * `gamma` – Expansion factor (≥ 1). Each node stores up to `gamma * M`
+    ///   neighbors. Larger values improve recall at the cost of memory and build time.
+    pub fn build_acorn_gamma_neighbors(&self, gamma: usize) -> AcornGammaNeighbors {
+        let n = self.dataset.len();
+        let m = self.num_neighbors_per_vec;
+        let gamma_m = (gamma * m).max(1);
+        let ground_graph = &self.levels[self.levels.len() - 1];
+
+        let mut expanded: Vec<Box<[usize]>> = Vec::with_capacity(n);
+
+        for v in 0..n {
+            // Collect the two-hop neighborhood, excluding v itself.
+            let mut seen: HashSet<usize> = HashSet::new();
+            seen.insert(v);
+            let mut candidates: Vec<usize> = Vec::new();
+
+            for u in ground_graph.neighbors(v) {
+                if seen.insert(u) {
+                    candidates.push(u);
+                }
+                for w in ground_graph.neighbors(u) {
+                    if seen.insert(w) {
+                        candidates.push(w);
+                    }
+                }
+            }
+
+            // Score each candidate by distance to v.
+            let v_vec = self.dataset.get(v as VectorId);
+            let eval = self.dataset.encoder().vector_evaluator(v_vec);
+
+            let mut scored: Vec<(<D::Encoder as VectorEncoder>::Distance, usize)> = candidates
+                .into_iter()
+                .map(|u| {
+                    let d = eval.compute_distance(self.dataset.get(u as VectorId));
+                    (d, u)
+                })
+                .collect();
+
+            // Sort ascending (closest first), truncate to gamma * M.
+            scored.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+            scored.truncate(gamma_m);
+
+            expanded.push(
+                scored
+                    .into_iter()
+                    .map(|(_, u)| u)
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice(),
+            );
+        }
+
+        AcornGammaNeighbors {
+            neighbors: expanded.into_boxed_slice(),
+            gamma_m,
+        }
+    }
+
+    /// ACORN-γ filtered approximate nearest-neighbor search.
+    ///
+    /// Unlike ACORN-1 ([`search_filtered`]), the two-hop expansion is
+    /// **pre-computed** at index construction time (via
+    /// [`build_acorn_gamma_neighbors`]). At search time, standard beam search
+    /// runs over the pre-expanded neighbor lists; predicate-failing nodes are
+    /// simply skipped — no on-the-fly two-hop expansion is needed.
+    ///
+    /// # Arguments
+    /// * `query` – The query vector.
+    /// * `k` – Number of nearest neighbors to return.
+    /// * `search_params` – Search configuration (`ef_search`, early termination).
+    /// * `acorn_gamma` – Pre-built expanded neighbor lists (from `build_acorn_gamma_neighbors`).
+    /// * `predicate` – `Fn(vector_id: usize) -> bool`. Only vectors satisfying
+    ///   this will appear in the results.
+    pub fn search_filtered_gamma<'q, F>(
+        &'q self,
+        query: <D::Encoder as VectorEncoder>::QueryVector<'q>,
+        k: usize,
+        search_params: &HNSWSearchConfiguration,
+        acorn_gamma: &AcornGammaNeighbors,
+        predicate: F,
+    ) -> Vec<vectorium::dataset::ScoredVector<<D::Encoder as VectorEncoder>::Distance>>
+    where
+        F: Fn(usize) -> bool,
+    {
+        let query_eval = self.dataset.encoder().query_evaluator(query);
+        let num_levels = self.levels.len();
+
+        // --- Stage 1: upper levels (unfiltered greedy search, same as ACORN-1) ---
+        let entry_graph = if num_levels > 1 {
+            &self.levels[0]
+        } else {
+            &self.levels[num_levels - 1]
+        };
+        let entry_external_id = entry_graph.get_external_id(self.entry_point) as VectorId;
+        let entry_distance = query_eval.compute_distance(self.dataset.get(entry_external_id));
+        let mut entry_node = ScoredItemGeneric {
+            distance: entry_distance,
+            vector: self.entry_point,
+        };
+        if num_levels > 1 {
+            for level_graph in &self.levels[..num_levels - 1] {
+                entry_node =
+                    level_graph.greedy_search_nearest(&self.dataset, &query_eval, entry_node);
+            }
+        }
+
+        // --- Stage 2: ground level (ACORN-γ search on pre-expanded neighbor lists) ---
+        let entry_global_id = if num_levels > 1 {
+            self.level1_to_level0_mapping[entry_node.vector]
+        } else {
+            self.entry_point
+        };
+        let ground_entry_node = ScoredItemGeneric {
+            distance: entry_node.distance,
+            vector: entry_global_id,
+        };
+
+        let ef = search_params.ef_search.max(k);
+        let lambda = search_params.early_termination.lambda();
+        let top_heap = acorn_gamma.acorn_gamma_search_filtered(
             &self.dataset,
             ground_entry_node,
             &query_eval,
@@ -1250,5 +1465,99 @@ mod acorn_search_tests {
 
         let results = hnsw.search_filtered(query, 5, &search_config, |_| false);
         assert!(results.is_empty(), "expected empty results when predicate always returns false");
+    }
+}
+
+#[cfg(test)]
+mod acorn_gamma_search_tests {
+    use super::*;
+    use crate::graph::Graph;
+    use crate::index::Index;
+    use vectorium::distances::SquaredEuclideanDistance;
+    use vectorium::encoders::dense_scalar::PlainDenseQuantizer;
+    use vectorium::vector::DenseVectorView;
+    use vectorium::{DenseDataset, PlainDenseDataset};
+
+    fn build_1d_hnsw(n: usize) -> HNSW<PlainDenseDataset<f32, SquaredEuclideanDistance>, Graph> {
+        let encoder = PlainDenseQuantizer::<f32, SquaredEuclideanDistance>::new(1);
+        let flat: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        let dataset = DenseDataset::from_raw(flat.into_boxed_slice(), n, encoder);
+        let config = HNSWBuildConfiguration::default()
+            .with_num_neighbors(8)
+            .with_ef_construction(50);
+        HNSW::build_index(dataset, &config)
+    }
+
+    /// `build_acorn_gamma_neighbors` with gamma=2 must produce at least as many
+    /// neighbors per node as the original ground graph (two-hop union is a superset).
+    #[test]
+    fn build_acorn_gamma_neighbors_expands_neighbor_lists() {
+        let hnsw = build_1d_hnsw(50);
+        let acorn_gamma = hnsw.build_acorn_gamma_neighbors(2);
+
+        let n = 50usize;
+        assert_eq!(acorn_gamma.n_nodes(), n);
+
+        let ground = &hnsw.levels[hnsw.levels.len() - 1];
+        for v in 0..n {
+            let orig_deg = ground.neighbors(v).count();
+            let expanded_deg = acorn_gamma.neighbors(v).count();
+            // Two-hop union is at least as large as one-hop.
+            assert!(
+                expanded_deg >= orig_deg,
+                "node {v}: expanded {expanded_deg} < original {orig_deg}"
+            );
+        }
+    }
+
+    /// Every result of `search_filtered_gamma` must pass the predicate.
+    #[test]
+    fn search_filtered_gamma_all_results_pass_predicate() {
+        let hnsw = build_1d_hnsw(100);
+        let search_config = HNSWSearchConfiguration::default().with_ef_search(50);
+        let acorn_gamma = hnsw.build_acorn_gamma_neighbors(4);
+
+        let query_val = [50.0f32];
+        let query = DenseVectorView::new(&query_val);
+
+        let results =
+            hnsw.search_filtered_gamma(query, 10, &search_config, &acorn_gamma, |id| id % 2 == 0);
+
+        assert!(!results.is_empty());
+        for r in &results {
+            assert_eq!(r.vector % 2, 0, "node {} fails even predicate", r.vector);
+        }
+    }
+
+    /// With an all-pass predicate, `search_filtered_gamma` must find the true nearest.
+    #[test]
+    fn search_filtered_gamma_full_predicate_finds_nearest() {
+        let hnsw = build_1d_hnsw(100);
+        let search_config = HNSWSearchConfiguration::default().with_ef_search(50);
+        let acorn_gamma = hnsw.build_acorn_gamma_neighbors(4);
+
+        let query_val = [37.0f32];
+        let query = DenseVectorView::new(&query_val);
+
+        let results =
+            hnsw.search_filtered_gamma(query, 1, &search_config, &acorn_gamma, |_| true);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].vector, 37, "nearest to 37.0 should be node 37");
+    }
+
+    /// When no vector satisfies the predicate, the result must be empty.
+    #[test]
+    fn search_filtered_gamma_no_eligible_vectors_returns_empty() {
+        let hnsw = build_1d_hnsw(50);
+        let search_config = HNSWSearchConfiguration::default().with_ef_search(50);
+        let acorn_gamma = hnsw.build_acorn_gamma_neighbors(2);
+
+        let query_val = [25.0f32];
+        let query = DenseVectorView::new(&query_val);
+
+        let results =
+            hnsw.search_filtered_gamma(query, 5, &search_config, &acorn_gamma, |_| false);
+        assert!(results.is_empty());
     }
 }

--- a/src/indexes/hnsw.rs
+++ b/src/indexes/hnsw.rs
@@ -267,6 +267,97 @@ where
     }
 }
 
+impl<D, G> HNSW<D, G>
+where
+    D: Dataset + Sync,
+    <D::Encoder as VectorEncoder>::Distance: vectorium::distances::Distance,
+    G: GraphTrait + From<GrowableGraph>,
+{
+    /// Performs ACORN-1 filtered approximate nearest-neighbor search.
+    ///
+    /// Returns the `k` approximate nearest neighbors of `query` that satisfy
+    /// `predicate(vector_id) == true`. Unlike a simple post-filter, the predicate
+    /// is applied *during* graph traversal: non-matching nodes are skipped and their
+    /// neighbors are inspected via a two-hop expansion to maintain connectivity in
+    /// the filtered sub-graph.
+    ///
+    /// The HNSW index does **not** need to be rebuilt; this method works on any
+    /// standard HNSW index (ACORN-1 variant).
+    ///
+    /// # Arguments
+    /// * `query` – The query vector.
+    /// * `k` – Number of nearest neighbors to return.
+    /// * `search_params` – Search configuration (`ef_search`, early termination).
+    /// * `predicate` – `Fn(vector_id: usize) -> bool`. Called with the global
+    ///   (dataset-level) vector ID; only vectors for which this returns `true`
+    ///   will appear in results.
+    pub fn search_filtered<'q, F>(
+        &'q self,
+        query: <D::Encoder as VectorEncoder>::QueryVector<'q>,
+        k: usize,
+        search_params: &HNSWSearchConfiguration,
+        predicate: F,
+    ) -> Vec<vectorium::dataset::ScoredVector<<D::Encoder as VectorEncoder>::Distance>>
+    where
+        F: Fn(usize) -> bool,
+    {
+        let query_eval = self.dataset.encoder().query_evaluator(query);
+        let num_levels = self.levels.len();
+
+        // --- Stage 1: upper levels (unfiltered greedy search, same as standard HNSW) ---
+        let entry_graph = if num_levels > 1 {
+            &self.levels[0]
+        } else {
+            &self.levels[num_levels - 1]
+        };
+        let entry_external_id = entry_graph.get_external_id(self.entry_point) as VectorId;
+        let entry_distance = query_eval.compute_distance(self.dataset.get(entry_external_id));
+        let mut entry_node = ScoredItemGeneric {
+            distance: entry_distance,
+            vector: self.entry_point,
+        };
+        if num_levels > 1 {
+            for level_graph in &self.levels[..num_levels - 1] {
+                entry_node =
+                    level_graph.greedy_search_nearest(&self.dataset, &query_eval, entry_node);
+            }
+        }
+
+        // --- Stage 2: ground level (ACORN-1 filtered search) ---
+        let ground_graph = &self.levels[num_levels - 1];
+        let entry_global_id = if num_levels > 1 {
+            self.level1_to_level0_mapping[entry_node.vector]
+        } else {
+            self.entry_point
+        };
+        let ground_entry_node = ScoredItemGeneric {
+            distance: entry_node.distance,
+            vector: entry_global_id,
+        };
+
+        let ef = search_params.ef_search.max(k);
+        let lambda = search_params.early_termination.lambda();
+        let top_heap = ground_graph.acorn_search_candidates_filtered(
+            &self.dataset,
+            ground_entry_node,
+            &query_eval,
+            ef,
+            k,
+            lambda,
+            &predicate,
+        );
+
+        let mut topk = top_heap.into_sorted_vec();
+        topk.truncate(k);
+        topk.drain(..)
+            .map(|candidate| vectorium::dataset::ScoredVector {
+                distance: candidate.distance,
+                vector: candidate.vector as VectorId,
+            })
+            .collect()
+    }
+}
+
 impl<D, G> Index<D> for HNSW<D, G>
 where
     D: Dataset + Sync + SpaceUsage,
@@ -1035,5 +1126,129 @@ mod convert_dataset_tests {
 
         assert!(!results.is_empty());
         assert!(results.len() <= 5);
+    }
+}
+
+#[cfg(test)]
+mod acorn_search_tests {
+    use super::*;
+    use crate::graph::Graph;
+    use crate::index::Index;
+    use vectorium::distances::SquaredEuclideanDistance;
+    use vectorium::encoders::dense_scalar::PlainDenseQuantizer;
+    use vectorium::vector::DenseVectorView;
+    use vectorium::{DenseDataset, PlainDenseDataset};
+
+    /// Build a small 1-D HNSW for testing.
+    /// Vectors are [0.0], [1.0], ..., [(n-1).0].
+    fn build_1d_hnsw(n: usize) -> HNSW<PlainDenseDataset<f32, SquaredEuclideanDistance>, Graph> {
+        let encoder = PlainDenseQuantizer::<f32, SquaredEuclideanDistance>::new(1);
+        let flat: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        let dataset = DenseDataset::from_raw(flat.into_boxed_slice(), n, encoder);
+        let config = HNSWBuildConfiguration::default()
+            .with_num_neighbors(8)
+            .with_ef_construction(50);
+        HNSW::build_index(dataset, &config)
+    }
+
+    /// Every result of `search_filtered` must pass the predicate.
+    #[test]
+    fn search_filtered_all_results_pass_predicate() {
+        let hnsw = build_1d_hnsw(100);
+        let search_config = HNSWSearchConfiguration::default().with_ef_search(50);
+
+        let query_val = [50.0f32];
+        let query = DenseVectorView::new(&query_val);
+
+        // Only even IDs allowed.
+        let results = hnsw.search_filtered(query, 10, &search_config, |id| id % 2 == 0);
+
+        assert!(!results.is_empty());
+        for r in &results {
+            assert_eq!(r.vector % 2, 0, "result {} does not pass even predicate", r.vector);
+        }
+    }
+
+    /// The nearest filtered result should be the closest vector satisfying the predicate.
+    ///
+    /// Query = 50.5.  Predicate: id divisible by 3.
+    /// Nearest divisible-by-3 IDs to 50.5 are 51 (d=0.25), 48 (d=6.25), 54 (d=12.25) …
+    #[test]
+    fn search_filtered_finds_nearest_predicate_passing_neighbors() {
+        let hnsw = build_1d_hnsw(100);
+        let search_config = HNSWSearchConfiguration::default().with_ef_search(100);
+
+        let query_val = [50.5f32];
+        let query = DenseVectorView::new(&query_val);
+
+        let results = hnsw.search_filtered(query, 5, &search_config, |id| id % 3 == 0);
+
+        assert!(!results.is_empty());
+        for r in &results {
+            assert_eq!(r.vector % 3, 0, "result {} is not divisible by 3", r.vector);
+        }
+        // The closest divisible-by-3 vector to 50.5 is 51.
+        assert_eq!(
+            results[0].vector, 51,
+            "expected nearest filtered result 51, got {}",
+            results[0].vector
+        );
+    }
+
+    /// With a predicate that accepts every vector, filtered search must return at
+    /// most `k` results and the nearest neighbor must match the unfiltered search.
+    #[test]
+    fn search_filtered_full_predicate_matches_unfiltered_nearest() {
+        let hnsw = build_1d_hnsw(100);
+        let search_config = HNSWSearchConfiguration::default().with_ef_search(50);
+        let k = 5;
+
+        let query_val = [30.0f32];
+        let query_filtered = DenseVectorView::new(&query_val);
+        let query_plain = DenseVectorView::new(&query_val);
+
+        let filtered = hnsw.search_filtered(query_filtered, k, &search_config, |_| true);
+        let plain = hnsw.search(query_plain, k, &search_config);
+
+        assert_eq!(filtered.len(), plain.len());
+        // Both searches must agree on the nearest neighbor.
+        assert_eq!(
+            filtered[0].vector, plain[0].vector,
+            "nearest neighbor mismatch: filtered={}, plain={}",
+            filtered[0].vector, plain[0].vector
+        );
+    }
+
+    /// When the predicate is very selective (only 1 vector passes), filtered search
+    /// must still return exactly that vector — provided the query is placed near it
+    /// so the HNSW entry point lands in the same neighbourhood.
+    #[test]
+    fn search_filtered_single_eligible_vector() {
+        let hnsw = build_1d_hnsw(50);
+        let search_config = HNSWSearchConfiguration::default().with_ef_search(50);
+
+        // Query near 42 so the HNSW navigates to that neighbourhood.
+        // The two-hop expansion from nearby nodes will reach node 42.
+        let query_val = [42.0f32];
+        let query = DenseVectorView::new(&query_val);
+
+        // Only vector 42 passes the predicate.
+        let results = hnsw.search_filtered(query, 5, &search_config, |id| id == 42);
+
+        assert_eq!(results.len(), 1, "expected exactly 1 result, got {}", results.len());
+        assert_eq!(results[0].vector, 42);
+    }
+
+    /// When no vector satisfies the predicate, the result must be empty.
+    #[test]
+    fn search_filtered_no_eligible_vectors_returns_empty() {
+        let hnsw = build_1d_hnsw(50);
+        let search_config = HNSWSearchConfiguration::default().with_ef_search(50);
+
+        let query_val = [25.0f32];
+        let query = DenseVectorView::new(&query_val);
+
+        let results = hnsw.search_filtered(query, 5, &search_config, |_| false);
+        assert!(results.is_empty(), "expected empty results when predicate always returns false");
     }
 }

--- a/src/pylib/mod.rs
+++ b/src/pylib/mod.rs
@@ -1,7 +1,7 @@
 use std::f32;
 
 use crate::graph::Graph;
-use crate::hnsw::{HNSW, HNSWBuildConfiguration, HNSWSearchConfiguration};
+use crate::hnsw::{AcornGammaNeighbors, HNSW, HNSWBuildConfiguration, HNSWSearchConfiguration};
 use crate::index::Index;
 use vectorium::IndexSerializer;
 
@@ -135,6 +135,7 @@ enum DensePlainHNSWEnum {
 #[pyclass]
 pub struct DensePlainHNSW {
     inner: DensePlainHNSWEnum,
+    acorn_gamma: Option<AcornGammaNeighbors>,
 }
 
 #[pymethods]
@@ -162,7 +163,7 @@ impl DensePlainHNSW {
             }
         };
 
-        Ok(DensePlainHNSW { inner })
+        Ok(DensePlainHNSW { inner, acorn_gamma: None })
     }
 
     #[staticmethod]
@@ -195,7 +196,7 @@ impl DensePlainHNSW {
             }
         };
 
-        Ok(DensePlainHNSW { inner })
+        Ok(DensePlainHNSW { inner, acorn_gamma: None })
     }
 
     pub fn save(&self, path: &str) -> PyResult<()> {
@@ -224,7 +225,7 @@ impl DensePlainHNSW {
                 DensePlainHNSWEnum::DotProduct(index)
             }
         };
-        Ok(DensePlainHNSW { inner })
+        Ok(DensePlainHNSW { inner, acorn_gamma: None })
     }
 
     pub fn search(
@@ -340,6 +341,87 @@ impl DensePlainHNSW {
             }
             DensePlainHNSWEnum::DotProduct(index) => {
                 let results = index.search_filtered(query_view, k, &search_config, &pred_fn);
+                push_results(results, &mut distances, &mut ids);
+            }
+        }
+
+        let distances_array = PyArray1::from_vec(py, distances).to_owned();
+        let ids_array = PyArray1::from_vec(py, ids).to_owned();
+        Ok((distances_array.into(), ids_array.into()))
+    }
+
+    /// Pre-compute expanded neighbor lists for ACORN-γ filtered search.
+    ///
+    /// Call this once after building the index. The expanded lists are stored on
+    /// the index object and used by [`search_filtered_gamma`].
+    ///
+    /// # Arguments
+    /// * `gamma` – Expansion factor (≥ 1). Each node stores up to `gamma × M`
+    ///   neighbors (two-hop union, pruned by distance). Larger values improve recall
+    ///   at the cost of memory and build time. A value of 2–4 is a good starting point.
+    pub fn build_acorn_gamma(&mut self, gamma: usize) {
+        let neighbors = match &self.inner {
+            DensePlainHNSWEnum::Euclidean(index) => index.build_acorn_gamma_neighbors(gamma),
+            DensePlainHNSWEnum::DotProduct(index) => index.build_acorn_gamma_neighbors(gamma),
+        };
+        self.acorn_gamma = Some(neighbors);
+    }
+
+    /// ACORN-γ filtered search: returns the `k` approximate nearest neighbors of
+    /// `query` for which `predicate(vector_id)` returns `True`.
+    ///
+    /// Requires [`build_acorn_gamma`] to have been called first.
+    ///
+    /// Unlike ACORN-1 ([`search_filtered`]), the two-hop connectivity is pre-baked
+    /// into the index at build time, so predicate-failing nodes are simply skipped
+    /// during traversal — no on-the-fly two-hop expansion is performed.
+    ///
+    /// # Arguments
+    /// * `query` – 1-D float32 numpy array of dimension `dim`.
+    /// * `k` – Number of nearest neighbors to return.
+    /// * `ef_search` – Candidate list size (higher = better recall, slower).
+    /// * `predicate` – Python callable `(int) -> bool`. Receives a global vector
+    ///   ID (0-based) and must return `True` for eligible vectors.
+    ///
+    /// # Returns
+    /// `(distances, ids)` – two 1-D numpy arrays of length ≤ `k`.
+    pub fn search_filtered_gamma(
+        &self,
+        py: Python<'_>,
+        query: PyReadonlyArray1<f32>,
+        k: usize,
+        ef_search: usize,
+        predicate: PyObject,
+    ) -> PyResult<(Py<PyArray1<f32>>, Py<PyArray1<i64>>)> {
+        let acorn_gamma = self.acorn_gamma.as_ref().ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "ACORN-γ neighbor lists not built. Call `build_acorn_gamma(gamma)` first.",
+            )
+        })?;
+
+        let query_slice = query.as_slice()?;
+        let query_view = DenseVectorView::new(query_slice);
+        let search_config = HNSWSearchConfiguration::default().with_ef_search(ef_search);
+
+        let pred_fn = |id: usize| -> bool {
+            predicate
+                .call1(py, (id as i64,))
+                .and_then(|r| r.extract::<bool>(py))
+                .unwrap_or(false)
+        };
+
+        let mut distances = Vec::with_capacity(k);
+        let mut ids = Vec::with_capacity(k);
+
+        match &self.inner {
+            DensePlainHNSWEnum::Euclidean(index) => {
+                let results =
+                    index.search_filtered_gamma(query_view, k, &search_config, acorn_gamma, &pred_fn);
+                push_results(results, &mut distances, &mut ids);
+            }
+            DensePlainHNSWEnum::DotProduct(index) => {
+                let results =
+                    index.search_filtered_gamma(query_view, k, &search_config, acorn_gamma, &pred_fn);
                 push_results(results, &mut distances, &mut ids);
             }
         }

--- a/src/pylib/mod.rs
+++ b/src/pylib/mod.rs
@@ -296,6 +296,58 @@ impl DensePlainHNSW {
             Ok((distances_array.into(), ids_array.into()))
         })
     }
+
+    /// ACORN-1 filtered search: returns the `k` approximate nearest neighbors
+    /// of `query` for which `predicate(vector_id)` returns `True`.
+    ///
+    /// The standard HNSW index is used as-is; no rebuilding is required.
+    ///
+    /// # Arguments
+    /// * `query` – 1-D float32 numpy array of dimension `dim`.
+    /// * `k` – Number of nearest neighbors to return.
+    /// * `ef_search` – Candidate list size (higher = better recall, slower).
+    /// * `predicate` – Python callable `(int) -> bool`. Receives a global vector
+    ///   ID (0-based) and must return `True` for vectors eligible as results.
+    ///
+    /// # Returns
+    /// `(distances, ids)` – two 1-D numpy arrays of length ≤ `k`.
+    pub fn search_filtered(
+        &self,
+        py: Python<'_>,
+        query: PyReadonlyArray1<f32>,
+        k: usize,
+        ef_search: usize,
+        predicate: PyObject,
+    ) -> PyResult<(Py<PyArray1<f32>>, Py<PyArray1<i64>>)> {
+        let query_slice = query.as_slice()?;
+        let query_view = DenseVectorView::new(query_slice);
+        let search_config = HNSWSearchConfiguration::default().with_ef_search(ef_search);
+
+        let pred_fn = |id: usize| -> bool {
+            predicate
+                .call1(py, (id as i64,))
+                .and_then(|r| r.extract::<bool>(py))
+                .unwrap_or(false)
+        };
+
+        let mut distances = Vec::with_capacity(k);
+        let mut ids = Vec::with_capacity(k);
+
+        match &self.inner {
+            DensePlainHNSWEnum::Euclidean(index) => {
+                let results = index.search_filtered(query_view, k, &search_config, &pred_fn);
+                push_results(results, &mut distances, &mut ids);
+            }
+            DensePlainHNSWEnum::DotProduct(index) => {
+                let results = index.search_filtered(query_view, k, &search_config, &pred_fn);
+                push_results(results, &mut distances, &mut ids);
+            }
+        }
+
+        let distances_array = PyArray1::from_vec(py, distances).to_owned();
+        let ids_array = PyArray1::from_vec(py, ids).to_owned();
+        Ok((distances_array.into(), ids_array.into()))
+    }
 }
 
 // Dense plain f16


### PR DESCRIPTION
This change implements [the ACORN-1 and ACORN-\gamma algorithms](https://arxiv.org/abs/2403.04871) along with unit tests and Python bindings.

I have also added a script to run tests against a small benchmark dataset, which you can invoke using the following command line:

`python scripts/acorn_benchmark.py --ef-search 20 50 100 200 --gamma 2 4 8`

producing a table like the one below:

```
========================================================================================
Summary  —  k=10  selectivity≈78.2%  (50 queries)
========================================================================================
   γ      ef  Method                       Recall@k   Mean lat   p95 lat
----------------------------------------------------------------------------------------
   2      20  Post-filter  (ef=20)           0.7100       0.1ms      0.1ms
              ACORN-1      (ef=20)           0.8880       0.8ms      3.2ms
              ACORN-gamma  (ef=20)           0.9100       0.3ms      1.5ms

          50  Post-filter  (ef=50)           0.8640       0.1ms      0.1ms
              ACORN-1      (ef=50)           0.9560       1.4ms      5.4ms
              ACORN-gamma  (ef=50)           0.9480       0.7ms      3.5ms

         100  Post-filter  (ef=100)          0.9140       0.2ms      0.3ms
              ACORN-1      (ef=100)          0.9700       2.2ms      8.5ms
              ACORN-gamma  (ef=100)          0.9760       1.1ms      5.6ms

         200  Post-filter  (ef=200)          0.9660       0.4ms      0.5ms
              ACORN-1      (ef=200)          0.9760       3.6ms     13.0ms
              ACORN-gamma  (ef=200)          0.9820       1.9ms      9.0ms

   4      20  Post-filter  (ef=20)           0.7100       0.1ms      0.1ms
              ACORN-1      (ef=20)           0.8880       0.8ms      3.2ms
              ACORN-gamma  (ef=20)           0.9620       0.5ms      2.1ms

          50  Post-filter  (ef=50)           0.8640       0.1ms      0.2ms
              ACORN-1      (ef=50)           0.9560       1.5ms      5.7ms
              ACORN-gamma  (ef=50)           0.9880       0.9ms      4.6ms

         100  Post-filter  (ef=100)          0.9140       0.2ms      0.3ms
              ACORN-1      (ef=100)          0.9700       2.3ms      8.9ms
              ACORN-gamma  (ef=100)          0.9880       1.5ms      7.2ms

         200  Post-filter  (ef=200)          0.9660       0.4ms      0.5ms
              ACORN-1      (ef=200)          0.9760       3.6ms     13.7ms
              ACORN-gamma  (ef=200)          0.9900       2.5ms     11.3ms

   8      20  Post-filter  (ef=20)           0.7100       0.1ms      0.1ms
              ACORN-1      (ef=20)           0.8880       0.8ms      3.2ms
              ACORN-gamma  (ef=20)           0.9800       0.7ms      3.1ms

          50  Post-filter  (ef=50)           0.8640       0.1ms      0.1ms
              ACORN-1      (ef=50)           0.9560       1.4ms      5.6ms
              ACORN-gamma  (ef=50)           0.9920       1.4ms      6.2ms

         100  Post-filter  (ef=100)          0.9140       0.2ms      0.3ms
              ACORN-1      (ef=100)          0.9700       2.3ms      8.9ms
              ACORN-gamma  (ef=100)          0.9920       2.1ms      9.9ms

         200  Post-filter  (ef=200)          0.9660       0.4ms      0.5ms
              ACORN-1      (ef=200)          0.9760       3.6ms     13.5ms
              ACORN-gamma  (ef=200)          0.9920       3.3ms     14.1ms

========================================================================================
```